### PR TITLE
Finish the withdraw challenge

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ fn process_instruction(
 ) -> ProgramResult {
     match instruction_data.split_first() {
         Some((Deposit::DISCRIMINATOR, data)) => Deposit::try_from((data, accounts))?.process(),
-        Some((Withdraw::DISCRIMINATOR, _)) => Withdraw::try_from(accounts)?.process(),
+        Some((Withdraw::DISCRIMINATOR, data)) => Withdraw::try_from((data, accounts))?.process(),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }


### PR DESCRIPTION
- User can now withdraw
- Security is based on recreating the same seeds from the same signer
- Rename test to reflect addition of withdraw code